### PR TITLE
Shorten Swedish weekday names to fit in picker

### DIFF
--- a/locales.js
+++ b/locales.js
@@ -330,13 +330,13 @@ const locales = {
   /* Swedish (Sweden) */
     'sv_sv-SE': {
         days: [
-            `Söndag`,
-            `Måndag`,
-            `Tisdag`,
-            `Onsdag`,
-            `Torsdag`,
-            `Fredag`,
-            `Lördag`
+            `Må`,
+            `Ti`,
+            `On`,
+            `To`,
+            `Fr`,
+            `Lö`,
+            `Sö`
         ],
         months: [
             `Januari`,


### PR DESCRIPTION
This PR does two things:

1. Change Swedish weekday names so that they fit within the datepicker. Without this change not all days are visible selectable within the datepicker.
2. Move Sunday last in the week as the Swedish locale expects weeks to begin on a Monday.